### PR TITLE
Test the error without relying on JSON's formatting of it

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -7,6 +7,8 @@ extern crate serde_json;
 extern crate base64;
 
 use base64::{encode_config, STANDARD};
+use serde::de::{Deserialize, Expected, IntoDeserializer, Unexpected};
+use std::fmt::{self, Display};
 
 base64_serde_type!(Base64Standard, STANDARD);
 
@@ -30,6 +32,36 @@ fn serde_with_type() {
 
 #[test]
 fn fails_nicely_on_inappropriate_input() {
-    assert_eq!("invalid type: integer `1234`, expected base64 ASCII text at line 1 column 13",
-               format!("{}", serde_json::from_str::<ByteHolder>("{\"bytes\":1234}").unwrap_err()));
+    #[derive(Debug)]
+    struct CheckError;
+
+    impl Display for CheckError {
+        fn fmt(&self, _formatter: &mut fmt::Formatter) -> fmt::Result {
+            unimplemented!()
+        }
+    }
+
+    impl std::error::Error for CheckError {
+        fn description(&self) -> &str {
+            unimplemented!()
+        }
+    }
+
+    impl serde::de::Error for CheckError {
+        fn custom<T: Display>(_msg: T) -> Self {
+            unimplemented!()
+        }
+
+        fn invalid_type(unexp: Unexpected, exp: &Expected) -> Self {
+            assert_eq!(unexp, Unexpected::Signed(1234));
+            assert_eq!(exp.to_string(), "base64 ASCII text");
+            CheckError
+        }
+    }
+
+    // The only way Serde could have constructed an error of type CheckError is
+    // through the invalid_type constructor, where we assert that the unexpected
+    // and expected values are what we intended.
+    let de = vec![1234].into_deserializer();
+    let _: CheckError = ByteHolder::deserialize(de).unwrap_err();
 }


### PR DESCRIPTION
I don't necessarily think this should be merged, but just to answer the question from https://github.com/marshallpierce/base64-serde/pull/4#pullrequestreview-64433162 of how the error could be tested without breaking if JSON decides to render the message a different way. Up to you!