### PR TITLE
Pub type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "base64-serde"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base64-serde"
-version = "0.1.0"
+version = "0.1.1"
 description = "Integration between rust-base64 and serde"
 authors = ["Marshall Pierce <marshall@mpierce.org>"]
 homepage = "https://github.com/marshallpierce/base64-serde"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,13 @@ pub use base64::{encode_config, decode_config};
 macro_rules! base64_serde_type {
     ($typename:ident, $config:expr) => {
         enum $typename {}
+        base64_serde_type!(impl_only, $typename, $config);
+    };
+    (pub $typename:ident, $config:expr) => {
+        pub enum $typename {}
+        base64_serde_type!(impl_only, $typename, $config);
+    };
+    (impl_only, $typename:ident, $config:expr) => {
         impl $typename {
             pub fn serialize<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>
                 where S: $crate::Serializer {
@@ -43,5 +50,5 @@ macro_rules! base64_serde_type {
                 deserializer.deserialize_str(Base64Visitor)
             }
         }
-    }
+    };
 }


### PR DESCRIPTION
Add a `pub $typename` syntax to the macro to set the generated enum's visibility to public.

I use the type in several modules, so I prefer to declare it only once as public and use it afterwards. Not sure if it makes sense (or if splitting the macro like I did is the right way to do it).