### PR TITLE
Extend deserializer output type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "base64-serde"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "base64 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base64-serde"
-version = "0.5.1"
+version = "0.6.0"
 description = "Integration between rust-base64 and serde"
 authors = ["Marshall Pierce <marshall@mpierce.org>"]
 homepage = "https://github.com/marshallpierce/base64-serde"

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,6 @@
 # 0.6.0
 
+- Now serializer works with any input type that implements `AsRef<[u8]>`
 - Now deserializer works with any output type that implements `From<Vec<u8>>`
 
 # 0.5.0

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,7 @@
+# 0.6.0
+
+- Now deserializer works with any output type that implements `From<Vec<u8>>`
+
 # 0.5.0
 
 - Use `base64` 0.12.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,11 @@ macro_rules! base64_serde_type {
                 serializer.serialize_str(&$crate::encode_config(bytes, $config))
             }
 
-            pub fn deserialize<'de, D>(deserializer: D) -> ::std::result::Result<Vec<u8>, D::Error>
-                where D: $crate::Deserializer<'de> {
+            pub fn deserialize<'de, D, Output>(deserializer: D) -> ::std::result::Result<Output, D::Error>
+                where 
+                    D: $crate::Deserializer<'de>,
+                    Output: From<Vec<u8>>
+            {
                 struct Base64Visitor;
 
                 impl<'de> $crate::de::Visitor<'de> for Base64Visitor {
@@ -51,7 +54,7 @@ macro_rules! base64_serde_type {
                     }
                 }
 
-                deserializer.deserialize_str(Base64Visitor)
+                deserializer.deserialize_str(Base64Visitor).map(|vec| Output::from(vec))
             }
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,9 +29,12 @@ macro_rules! base64_serde_type {
     };
     (impl_only, $typename:ident, $config:expr) => {
         impl $typename {
-            pub fn serialize<S>(bytes: &[u8], serializer: S) -> ::std::result::Result<S::Ok, S::Error>
-                where S: $crate::Serializer {
-                serializer.serialize_str(&$crate::encode_config(bytes, $config))
+            pub fn serialize<S, Input>(bytes: Input, serializer: S) -> ::std::result::Result<S::Ok, S::Error>
+                where
+                    S: $crate::Serializer,
+                    Input: AsRef<[u8]>
+            {
+                serializer.serialize_str(&$crate::encode_config(bytes.as_ref(), $config))
             }
 
             pub fn deserialize<'de, D, Output>(deserializer: D) -> ::std::result::Result<Output, D::Error>


### PR DESCRIPTION
So, I wasn't able to derive `Deserialize` for `RefCell<Vec<u8>>` because this crate has a fixed output `Vec<u8>`. I've changed it to generic `From<Vec<u8>>`, and now it works with `Vec<u8>` and any other type that implements `From<Vec<u8>>`.