### PR TITLE
Don't depend on `base64` and `serde` directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "base64"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64-serde"
@@ -19,48 +19,54 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -69,20 +75,21 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -91,6 +98,6 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "base64-serde"
-version = "0.7.0"
+version = "0.8.0"
 description = "Integration between rust-base64 and serde"
 authors = ["Marshall Pierce <marshall@mpierce.org>"]
 homepage = "https://github.com/marshallpierce/base64-serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,8 @@ rust-version = "1.57.0"
 edition = "2021"
 
 [dependencies]
-base64 = "0.21.0"
-serde = "1.0.152"
 
 [dev-dependencies]
-serde = { version = "1.0.152", features = ["derive"] }
-serde_json = "1.0.91"
+base64 = "0.22.1"
+serde = { version = "1.0.210", features = ["derive"] }
+serde_json = "1.0.128"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,3 @@
-extern crate base64;
-extern crate serde;
-
-#[doc(hidden)]
-pub use serde::{de, Deserializer, Serializer};
-
 /// Create a type with appropriate `serialize` and `deserialize` functions to use with
 /// serde when specifying how to serialize a particular field.
 ///
@@ -62,7 +56,7 @@ macro_rules! base64_serde_type {
                 serializer: S,
             ) -> ::std::result::Result<S::Ok, S::Error>
             where
-                S: $crate::Serializer,
+                S: serde::Serializer,
                 Input: AsRef<[u8]>,
             {
                 use base64::Engine as _;
@@ -73,12 +67,12 @@ macro_rules! base64_serde_type {
                 deserializer: D,
             ) -> ::std::result::Result<Output, D::Error>
             where
-                D: $crate::Deserializer<'de>,
+                D: serde::Deserializer<'de>,
                 Output: From<Vec<u8>>,
             {
                 struct Base64Visitor;
 
-                impl<'de> $crate::de::Visitor<'de> for Base64Visitor {
+                impl<'de> serde::de::Visitor<'de> for Base64Visitor {
                     type Value = Vec<u8>;
 
                     fn expecting(
@@ -90,10 +84,10 @@ macro_rules! base64_serde_type {
 
                     fn visit_str<E>(self, v: &str) -> ::std::result::Result<Self::Value, E>
                     where
-                        E: $crate::de::Error,
+                        E: serde::de::Error,
                     {
                         use base64::Engine as _;
-                        $engine.decode(v).map_err($crate::de::Error::custom)
+                        $engine.decode(v).map_err(serde::de::Error::custom)
                     }
                 }
 


### PR DESCRIPTION
Because the macro is expanded on the call-site, we can remove the direct dependencies and have the crate using us as a dep depend on `serde` and `base64` directly.

As long as the `base64` API does not change significatnly, we should be fine.

We bump the version as this is backwards incompatible.